### PR TITLE
Update to embedded-hal 1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Breaking changes
+### Changed
 - Updated to `embedded-hal` 1.0.
 
 ## [0.1.2] - 2023-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking changes
+- Updated to `embedded-hal` 1.0.
 
 ## [0.1.2] - 2023-03-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.9"
+linux-embedded-hal = "0.4.0"
+embedded-hal-mock = { version = "0.10.0", default-features = false, features = ["eh1"] }
 
 [profile.release]
 lto = true

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,10 +1,7 @@
 //! I2C/SPI interfaces
 
 use crate::{private, Error};
-use embedded_hal::{
-    blocking::{i2c, spi},
-    digital,
-};
+use embedded_hal::{i2c, spi::SpiDevice};
 
 const I2C_DEV_BASE_ADDR: u8 = 0x68;
 
@@ -17,9 +14,8 @@ pub struct I2cInterface<I2C> {
 
 /// SPI interface
 #[derive(Debug)]
-pub struct SpiInterface<SPI, CS> {
+pub struct SpiInterface<SPI> {
     pub(crate) spi: SPI,
-    pub(crate) cs: CS,
 }
 
 /// Possible slave addresses
@@ -61,9 +57,9 @@ pub trait WriteData: private::Sealed {
 
 impl<I2C, E> WriteData for I2cInterface<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
-    type Error = Error<E, ()>;
+    type Error = Error<E>;
     fn write_register(&mut self, register: u8, data: u8) -> Result<(), Self::Error> {
         let payload: [u8; 2] = [register, data];
         let addr = self.address;
@@ -76,28 +72,18 @@ where
     }
 }
 
-impl<SPI, CS, CommE, PinE> WriteData for SpiInterface<SPI, CS>
+impl<SPI, CommE> WriteData for SpiInterface<SPI>
 where
-    SPI: spi::Write<u8, Error = CommE>,
-    CS: digital::v2::OutputPin<Error = PinE>,
+    SPI: SpiDevice<u8, Error = CommE>,
 {
-    type Error = Error<CommE, PinE>;
+    type Error = Error<CommE>;
     fn write_register(&mut self, register: u8, data: u8) -> Result<(), Self::Error> {
-        self.cs.set_low().map_err(Error::Pin)?;
-
         let payload: [u8; 2] = [register, data];
-        let result = self.spi.write(&payload).map_err(Error::Comm);
-
-        self.cs.set_high().map_err(Error::Pin)?;
-        result
+        self.spi.write(&payload).map_err(Error::Comm)
     }
 
     fn write_data(&mut self, payload: &mut [u8]) -> Result<(), Self::Error> {
-        self.cs.set_low().map_err(Error::Pin)?;
-        let result = self.spi.write(payload).map_err(Error::Comm);
-
-        self.cs.set_high().map_err(Error::Pin)?;
-        result
+        self.spi.write(payload).map_err(Error::Comm)
     }
 }
 
@@ -113,9 +99,9 @@ pub trait ReadData: private::Sealed {
 
 impl<I2C, E> ReadData for I2cInterface<I2C>
 where
-    I2C: i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
-    type Error = Error<E, ()>;
+    type Error = Error<E>;
     fn read_register(&mut self, register: u8) -> Result<u8, Self::Error> {
         let mut data = [0];
         let addr = self.address;
@@ -134,26 +120,20 @@ where
     }
 }
 
-impl<SPI, CS, CommE, PinE> ReadData for SpiInterface<SPI, CS>
+impl<SPI, CommE> ReadData for SpiInterface<SPI>
 where
-    SPI: spi::Transfer<u8, Error = CommE>,
-    CS: digital::v2::OutputPin<Error = PinE>,
+    SPI: SpiDevice<u8, Error = CommE>,
 {
-    type Error = Error<CommE, PinE>;
+    type Error = Error<CommE>;
     fn read_register(&mut self, register: u8) -> Result<u8, Self::Error> {
-        self.cs.set_low().map_err(Error::Pin)?;
         let mut data = [register + 0x80, 0];
-        let result = self.spi.transfer(&mut data).map_err(Error::Comm);
-        self.cs.set_high().map_err(Error::Pin)?;
-        Ok(result?[1])
+        self.spi.transfer_in_place(&mut data).map_err(Error::Comm)?;
+        Ok(data[1])
     }
 
     fn read_data(&mut self, payload: &mut [u8]) -> Result<(), Self::Error> {
-        self.cs.set_low().map_err(Error::Pin)?;
         payload[0] += 0x80;
-        let result = self.spi.transfer(payload).map_err(Error::Comm);
-        self.cs.set_high().map_err(Error::Pin)?;
-        result?;
+        self.spi.transfer_in_place(payload).map_err(Error::Comm)?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,8 @@
 //! use bmi160::Bmi160;
 //!
 //! # fn main() {
-//! let spi = hal::Spidev::open("/dev/spidev0.0").unwrap();
-//! let chip_select = hal::Pin::new(25);
-//! let mut imu = Bmi160::new_with_spi(spi, chip_select);
+//! let spi = hal::SpidevDevice::open("/dev/spidev0.0").unwrap();
+//! let mut imu = Bmi160::new_with_spi(spi);
 //! let id = imu.chip_id().unwrap_or(0);
 //! println!("Chip ID: {}", id);
 //! # }
@@ -139,6 +138,6 @@ mod private {
     use super::interface;
     pub trait Sealed {}
 
-    impl<SPI, CS> Sealed for interface::SpiInterface<SPI, CS> {}
+    impl<SPI> Sealed for interface::SpiInterface<SPI> {}
     impl<I2C> Sealed for interface::I2cInterface<I2C> {}
 }

--- a/src/read_sensor_data.rs
+++ b/src/read_sensor_data.rs
@@ -3,12 +3,12 @@ use crate::{
     Bmi160, Data, Error, MagnetometerData, Register, Sensor3DData, SensorSelector,
 };
 
-impl<DI, CommE, PinE> Bmi160<DI>
+impl<DI, CommE> Bmi160<DI>
 where
-    DI: ReadData<Error = Error<CommE, PinE>> + WriteData<Error = Error<CommE, PinE>>,
+    DI: ReadData<Error = Error<CommE>> + WriteData<Error = Error<CommE>>,
 {
     /// Read latest sensor data
-    pub fn data(&mut self, selector: SensorSelector) -> Result<Data, Error<CommE, PinE>> {
+    pub fn data(&mut self, selector: SensorSelector) -> Result<Data, Error<CommE>> {
         let result = if selector != SensorSelector::new() {
             let (begin, end) = get_data_addresses(selector);
             let mut data = [0_u8; 24];

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,8 @@
 /// All possible errors in this crate
 #[derive(Debug)]
-pub enum Error<CommE, PinE> {
+pub enum Error<CommE> {
     /// I²C / SPI communication error
     Comm(CommE),
-    /// Chip-select pin error (SPI)
-    Pin(PinE),
     /// Invalid input data provided
     InvalidInputData,
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,6 @@
 use bmi160::{interface, Bmi160, SlaveAddr};
-use embedded_hal_mock::{
+use embedded_hal_mock::eh1::{
     i2c::{Mock as I2cMock, Transaction as I2cTrans},
-    pin::{Mock as PinMock, State as PinState, Transaction as PinTrans},
     spi::{Mock as SpiMock, Transaction as SpiTrans},
 };
 
@@ -20,23 +19,14 @@ impl Register {
 pub const DEV_ADDR: u8 = 0x68;
 
 #[allow(unused)]
-pub fn default_cs() -> PinMock {
-    PinMock::new(&[PinTrans::set(PinState::Low), PinTrans::set(PinState::High)])
+pub fn new_spi(transactions: &[SpiTrans<u8>]) -> Bmi160<interface::SpiInterface<SpiMock<u8>>> {
+    Bmi160::new_with_spi(SpiMock::new(transactions))
 }
 
 #[allow(unused)]
-pub fn new_spi(
-    transactions: &[SpiTrans],
-    cs: PinMock,
-) -> Bmi160<interface::SpiInterface<SpiMock, PinMock>> {
-    Bmi160::new_with_spi(SpiMock::new(transactions), cs)
-}
-
-#[allow(unused)]
-pub fn destroy_spi(imu: Bmi160<interface::SpiInterface<SpiMock, PinMock>>) {
-    let (mut spi, mut cs) = imu.destroy();
+pub fn destroy_spi(imu: Bmi160<interface::SpiInterface<SpiMock<u8>>>) {
+    let mut spi = imu.destroy();
     spi.done();
-    cs.done();
 }
 
 #[allow(unused)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 use bmi160::{Data, MagnetometerData, Sensor3DData, SensorSelector};
 mod common;
 use crate::common::{destroy_i2c, destroy_spi, new_i2c, new_spi, Register, DEV_ADDR};
-use embedded_hal_mock::{i2c::Transaction as I2cTrans, pin::Mock as PinMock};
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 #[test]
 fn can_create_and_destroy_i2c() {
@@ -11,7 +11,7 @@ fn can_create_and_destroy_i2c() {
 
 #[test]
 fn can_create_and_destroy_spi() {
-    let imu = new_spi(&[], PinMock::new(&[]));
+    let imu = new_spi(&[]);
     destroy_spi(imu);
 }
 
@@ -48,6 +48,7 @@ mod get_sensor_data {
         let mut imu = new_i2c(&[]);
         let result = imu.data(SensorSelector::new()).unwrap();
         assert_eq!(result, EMPTY);
+        destroy_i2c(imu);
     }
 
     #[test]
@@ -80,6 +81,7 @@ mod get_sensor_data {
             time: Some(0x171615),
         };
         assert_eq!(result, expected);
+        destroy_i2c(imu);
     }
 
     #[test]
@@ -101,6 +103,7 @@ mod get_sensor_data {
             time: Some(0x171615),
         };
         assert_eq!(result, expected);
+        destroy_i2c(imu);
     }
 
     #[test]
@@ -122,5 +125,6 @@ mod get_sensor_data {
             time: None,
         };
         assert_eq!(result, expected);
+        destroy_i2c(imu);
     }
 }

--- a/tests/power.rs
+++ b/tests/power.rs
@@ -1,7 +1,7 @@
 use bmi160::{AccelerometerPowerMode, GyroscopePowerMode, MagnetometerPowerMode, SensorPowerMode};
 mod common;
 use crate::common::{destroy_i2c, new_i2c, Register, DEV_ADDR};
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 macro_rules! get_pm_test {
     ($name:ident, $pmu:expr, $accel:ident, $gyro:ident, $magnet:ident) => {

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,7 +1,7 @@
 use bmi160::Status;
 mod common;
 use crate::common::{destroy_i2c, new_i2c, Register, DEV_ADDR};
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 macro_rules! get_st_test {
     ($name:ident, $st:expr, $drdy_acc:expr, $drdy_gyro:expr, $drdy_magnet:expr,


### PR DESCRIPTION
Among other changes, this splits out separate traits for SPI devices versus buses, so the driver no longer manages the CS pin directly.