### PR TITLE
Read scaled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added types and support for setting Accelerometer and Gyroscope Range
+
 ## [1.0.0] - 2024-01-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ inertial measurement unit using the [`embedded-hal`] traits.
 This driver allows you to:
 - Get the latest sensor data. See: `data()`.
 - Set the accelerometer, gyroscope and magnetometer power mode. See: `set_accel_power_mode()`.
+- Set the accelerometer and gyro range, See: `set_accel_range()` and `set_gyro_range()`.
 - Get the sensor status. See: `status()`.
 - Get power mode. See: `power_mode()`.
 - Get chip ID. See: `chip_id()`.

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -1,5 +1,6 @@
 use crate::{
     interface::{I2cInterface, ReadData, SpiInterface, WriteData},
+    types::{AccelerometerRange, GyroRange},
     AccelerometerPowerMode, BitFlags, Bmi160, Error, GyroscopePowerMode, MagnetometerPowerMode,
     Register, SensorPowerMode, SlaveAddr, Status,
 };
@@ -117,5 +118,15 @@ where
             MagnetometerPowerMode::LowPower => 0b0001_1010,
         };
         self.iface.write_register(Register::CMD, cmd)
+    }
+
+    /// Set the accelerometer range
+    pub fn set_accel_range(&mut self, range: AccelerometerRange) -> Result<(), Error<CommE>> {
+        self.iface.write_register(Register::ACC_RANGE, range as u8)
+    }
+
+    /// Set the gyro range
+    pub fn set_gyro_range(&mut self, range: GyroRange) -> Result<(), Error<CommE>> {
+        self.iface.write_register(Register::GYR_RANGE, range as u8)
     }
 }

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -13,6 +13,8 @@ impl<I2C> Bmi160<I2cInterface<I2C>> {
                 i2c,
                 address: address.addr(),
             },
+            accel_range: AccelerometerRange::default(),
+            gyro_range: GyroRange::default(),
         }
     }
 
@@ -27,6 +29,8 @@ impl<SPI> Bmi160<SpiInterface<SPI>> {
     pub fn new_with_spi(spi: SPI) -> Self {
         Bmi160 {
             iface: SpiInterface { spi },
+            accel_range: AccelerometerRange::default(),
+            gyro_range: GyroRange::default(),
         }
     }
 
@@ -122,11 +126,13 @@ where
 
     /// Set the accelerometer range
     pub fn set_accel_range(&mut self, range: AccelerometerRange) -> Result<(), Error<CommE>> {
+        self.accel_range = range;
         self.iface.write_register(Register::ACC_RANGE, range as u8)
     }
 
     /// Set the gyro range
     pub fn set_gyro_range(&mut self, range: GyroRange) -> Result<(), Error<CommE>> {
+        self.gyro_range = range;
         self.iface.write_register(Register::GYR_RANGE, range as u8)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,8 @@ pub mod interface;
 mod types;
 pub use crate::interface::SlaveAddr;
 pub use crate::types::{
-    AccelerometerPowerMode, Data, Error, GyroscopePowerMode, MagnetometerData,
-    MagnetometerPowerMode, Sensor3DData, SensorPowerMode, SensorSelector, Status,
+    AccelerometerPowerMode, AccelerometerRange, Data, Error, GyroRange, GyroscopePowerMode,
+    MagnetometerData, MagnetometerPowerMode, Sensor3DData, SensorPowerMode, SensorSelector, Status,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ mod read_sensor_data;
 pub struct Bmi160<DI> {
     /// Digital interface: I2C or SPI
     iface: DI,
+    accel_range: AccelerometerRange,
+    gyro_range: GyroRange,
 }
 
 mod private {

--- a/src/register_address.rs
+++ b/src/register_address.rs
@@ -8,6 +8,8 @@ impl Register {
     pub const ACC: u8 = 0x12;
     pub const SENSORTIME: u8 = 0x18;
     pub const CMD: u8 = 0x7E;
+    pub const ACC_RANGE: u8 = 0x41;
+    pub const GYR_RANGE: u8 = 0x43;
 }
 
 pub struct BitFlags;

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,14 +32,25 @@ pub enum AccelerometerPowerMode {
 /// Accelerometer Range.
 /// See 2.11.12 Register (0x41) ACC_RANGE;
 /// BMI160 BST-BMI160-DS000-09 Rev 1.0 p. 59
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum AccelerometerRange {
     /// +- 2G
+    #[default]
     G2 = 0b0000_0011,
     /// +- 4G
     G4 = 0b0000_0101,
     /// +- 8G
     G8 = 0b0000_1000,
+}
+
+impl AccelerometerRange {
+    pub(crate) fn multiplier(self) -> f32 {
+        match self {
+            AccelerometerRange::G2 => 1. / 16384.,
+            AccelerometerRange::G4 => 1. / 8192.,
+            AccelerometerRange::G8 => 1. / 4096.,
+        }
+    }
 }
 
 /// Gyroscope power mode
@@ -55,9 +66,10 @@ pub enum GyroscopePowerMode {
 
 /// 2.11.14 Register (0x43) GYR_RANGE
 /// BMI160 BST-BMI160-DS000-09 Rev 1.0 p. 61
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum GyroRange {
     /// 16.4 LSB/°/s <-> 61.0 m°/s / LSB
+    #[default]
     Scale2000 = 0b0000_0000,
     /// 32.8 LSB/°/s <-> 30.5 m°/s / LSB
     Scale1000 = 0b0000_0001,
@@ -67,6 +79,18 @@ pub enum GyroRange {
     Scale250 = 0b0000_0011,
     /// 262.4 LSB/°/s  3.8m°/s / LSB
     Scale125 = 0b0000_0100,
+}
+
+impl GyroRange {
+    pub(crate) fn multiplier(self) -> f32 {
+        match self {
+            GyroRange::Scale2000 => 1. / 16.4,
+            GyroRange::Scale1000 => 1. / 32.8,
+            GyroRange::Scale500 => 1. / 65.6,
+            GyroRange::Scale250 => 1. / 131.2,
+            GyroRange::Scale125 => 1. / 262.4,
+        }
+    }
 }
 
 /// Magnetometer power mode
@@ -189,6 +213,30 @@ pub struct Data {
     pub accel: Option<Sensor3DData>,
     /// Gyroscope data (if selected)
     pub gyro: Option<Sensor3DData>,
+    /// Magnetometer data (if selected)
+    pub magnet: Option<MagnetometerData>,
+    /// Time data (if selected)
+    pub time: Option<u32>,
+}
+
+/// Floating point 3D data
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Sensor3DDataScaled {
+    /// X axis data
+    pub x: f32,
+    /// Y axis data
+    pub y: f32,
+    /// Z axis data
+    pub z: f32,
+}
+
+/// Sensor data read
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DataScaled {
+    /// Accelerometer data (if selected)
+    pub accel: Option<Sensor3DDataScaled>,
+    /// Gyroscope data (if selected)
+    pub gyro: Option<Sensor3DDataScaled>,
     /// Magnetometer data (if selected)
     pub magnet: Option<MagnetometerData>,
     /// Time data (if selected)

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,6 +29,19 @@ pub enum AccelerometerPowerMode {
     LowPower,
 }
 
+/// Accelerometer Range.
+/// See 2.11.12 Register (0x41) ACC_RANGE;
+/// BMI160 BST-BMI160-DS000-09 Rev 1.0 p. 59
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AccelerometerRange {
+    /// +- 2G
+    G2 = 0b0000_0011,
+    /// +- 4G
+    G4 = 0b0000_0101,
+    /// +- 8G
+    G8 = 0b0000_1000,
+}
+
 /// Gyroscope power mode
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GyroscopePowerMode {
@@ -38,6 +51,22 @@ pub enum GyroscopePowerMode {
     Suspend,
     /// Fast start-up mode
     FastStartUp,
+}
+
+/// 2.11.14 Register (0x43) GYR_RANGE
+/// BMI160 BST-BMI160-DS000-09 Rev 1.0 p. 61
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GyroRange {
+    /// 16.4 LSB/°/s <-> 61.0 m°/s / LSB
+    Scale2000 = 0b0000_0000,
+    /// 32.8 LSB/°/s <-> 30.5 m°/s / LSB
+    Scale1000 = 0b0000_0001,
+    /// 65.6 LSB/°/s <-> 15.3 m°/s / LSB
+    Scale500 = 0b0000_0010,
+    /// 131.2 LSB/°/s <-> 7.6 m°/s / LSB
+    Scale250 = 0b0000_0011,
+    /// 262.4 LSB/°/s  3.8m°/s / LSB
+    Scale125 = 0b0000_0100,
 }
 
 /// Magnetometer power mode


### PR DESCRIPTION
This builds on https://github.com/eldruin/bmi160-rs/pull/8 to add function that returns the scaled output values for the set gyro and accelerometer range.

I don't fully understand the testing setup used in this repo so I didn't add any tests. I'm happy to add some if you can give some guidance on what you want tested.