### PR TITLE
Add feature to derive defmt::Format for public data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+- Added `defmt-03` feature that derives `defmt::Format` for public data types.
+
+## [1.1.0] - 2024-05-02
+
 ### Added
 - Added types and support for setting accelerometer and gyroscope ranges and retrieving scale sensor values.
 
@@ -30,7 +35,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release to crates.io.
 
-[Unreleased]: https://github.com/eldruin/bmi160-rs/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/eldruin/bmi160-rs/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/eldruin/bmi160-rs/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/eldruin/bmi160-rs/compare/v0.1.2...v1.0.0
 [0.1.2]: https://github.com/eldruin/bmi160-rs/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/eldruin/bmi160-rs/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2021"
 
 [dependencies]
 embedded-hal = "1.0.0"
+defmt = { version = "0.3.6", optional = true }
 
 [dev-dependencies]
 linux-embedded-hal = "0.4.0"
@@ -29,3 +30,6 @@ embedded-hal-mock = { version = "0.10.0", default-features = false, features = [
 
 [profile.release]
 lto = true
+
+[features]
+defmt = ["dep:defmt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ embedded-hal-mock = { version = "0.10.0", default-features = false, features = [
 lto = true
 
 [features]
-defmt = ["dep:defmt"]
+defmt-03 = ["dep:defmt"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ fn main() {
 }
 ```
 
+## Features
+
+- `defmt-03`: derives `defmt::Format` for public data types.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.62 and up. It *might*

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -20,6 +20,7 @@ pub struct SpiInterface<SPI> {
 
 /// Possible slave addresses
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SlaveAddr {
     /// Default slave address
     Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,10 @@
 //! }
 //! # }
 //! ```
+//!
+//! ## Features
+//!
+//! - `defmt-03`: derives `defmt::Format` for public data types.
 
 #![deny(unsafe_code, missing_docs)]
 #![no_std]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 /// All possible errors in this crate
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<CommE> {
     /// I²C / SPI communication error
     Comm(CommE),
@@ -9,6 +10,7 @@ pub enum Error<CommE> {
 
 /// Sensor power mode
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SensorPowerMode {
     /// Accelerometer power mode
     pub accel: AccelerometerPowerMode,
@@ -20,6 +22,7 @@ pub struct SensorPowerMode {
 
 /// Accelerometer power mode
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AccelerometerPowerMode {
     /// Normal mode
     Normal,
@@ -31,6 +34,7 @@ pub enum AccelerometerPowerMode {
 
 /// Accelerometer Range
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AccelerometerRange {
     /// +- 2G
     #[default]
@@ -53,6 +57,7 @@ impl AccelerometerRange {
 
 /// Gyroscope power mode
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GyroscopePowerMode {
     /// Normal mode
     Normal,
@@ -64,6 +69,7 @@ pub enum GyroscopePowerMode {
 
 /// Gyroscope range
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GyroscopeRange {
     /// 16.4 LSB/°/s <-> 61.0 m°/s / LSB
     #[default]
@@ -92,6 +98,7 @@ impl GyroscopeRange {
 
 /// Magnetometer power mode
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum MagnetometerPowerMode {
     /// Normal mode
     Normal,
@@ -103,6 +110,7 @@ pub enum MagnetometerPowerMode {
 
 /// Sensor status flags
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Status {
     /// Accelerometer has data ready
     pub accel_data_ready: bool,
@@ -122,6 +130,7 @@ pub struct Status {
 
 /// Sensor data read selector
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SensorSelector {
     pub(crate) accel: bool,
     pub(crate) gyro: bool,
@@ -185,6 +194,7 @@ impl Default for SensorSelector {
 
 /// Sensor data read selector
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Sensor3DData {
     /// X axis data
     pub x: i16,
@@ -196,6 +206,7 @@ pub struct Sensor3DData {
 
 /// Magnetometer data
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MagnetometerData {
     /// Axes data
     pub axes: Sensor3DData,
@@ -205,6 +216,7 @@ pub struct MagnetometerData {
 
 /// Sensor data read
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Data {
     /// Accelerometer data (if selected)
     pub accel: Option<Sensor3DData>,
@@ -218,6 +230,7 @@ pub struct Data {
 
 /// Floating point 3D data
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Sensor3DDataScaled {
     /// X axis data
     pub x: f32,
@@ -229,6 +242,7 @@ pub struct Sensor3DDataScaled {
 
 /// Sensor data read
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataScaled {
     /// Accelerometer data (if selected)
     pub accel: Option<Sensor3DDataScaled>,


### PR DESCRIPTION
This adds a `defmt` feature that when enabled derives `defmt::Format` for all public data types. This can be useful for debug purposes. 